### PR TITLE
Revert "Make sure we get epoch 0"

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -62,7 +62,7 @@ func Start(client rpc.Client) error {
 			logger.Fatal(err)
 		}
 
-		for epoch := uint64(0); epoch <= head.HeadEpoch; epoch++ {
+		for epoch := uint64(1); epoch <= head.HeadEpoch; epoch++ {
 			err := ExportEpoch(epoch, client)
 
 			if err != nil {
@@ -99,7 +99,7 @@ func Start(client rpc.Client) error {
 			logger.Fatal(err)
 		}
 
-		if len(epochs) == 0 || (len(epochs) > 0 && epochs[0] != 0) {
+		if len(epochs) > 0 && epochs[0] != 0 {
 			err := ExportEpoch(0, client)
 			if err != nil {
 				logger.Error(err)
@@ -135,7 +135,7 @@ func Start(client rpc.Client) error {
 			logger.Fatal(err)
 		}
 
-		nodeBlocks, err := GetLastBlocks(0, head.HeadEpoch, client)
+		nodeBlocks, err := GetLastBlocks(1, head.HeadEpoch, client)
 		if err != nil {
 			logger.Fatal(err)
 		}


### PR DESCRIPTION
This reverts commit 8cbfe49ffdb5910aeb2f86465a8b591081b1aec8.

This commit has not been tested.  
Therefore,  I believe that it should be removed for the time being.  
because
1. There is a module that handles the Genesis block separately.
2. It worked well before, but I don't know any special reason to modify it.