### PR TITLE
Add endpoint of API (/validator/{indexOrPubkey}/totalwithdrawals)

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -175,6 +175,7 @@ func main() {
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/proposals", handlers.ApiValidatorProposals).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/deposits", handlers.ApiValidatorDeposits).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/withdrawals", handlers.ApiValidatorWithdrawals).Methods("GET", "OPTIONS")
+		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/totalwithdrawals", handlers.ApiValidatorTotalWithdrawals).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/attestationefficiency", handlers.ApiValidatorAttestationEfficiency).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/validator/{indexOrPubkey}/attestationeffectiveness", handlers.ApiValidatorAttestationEffectiveness).Methods("GET", "OPTIONS")
 		apiV1Router.HandleFunc("/validator/stats/{index}", handlers.ApiValidatorDailyStats).Methods("GET", "OPTIONS")

--- a/db/db.go
+++ b/db/db.go
@@ -2324,6 +2324,21 @@ func GetValidatorsWithdrawals(validators []uint64, fromEpoch uint64, toEpoch uin
 	return withdrawals, nil
 }
 
+func GetValidatorTotalWithdrawals(validators []uint64) ([]*types.TotalWithdrawals, error) {
+	var totalwithdrawals []*types.TotalWithdrawals
+	err := ReaderDb.Select(&totalwithdrawals, `
+	SELECT
+		w.validatorindex, 
+		COALESCE(MAX(w.block_slot), 0) as slot,
+		COALESCE(SUM(w.amount), 0) as sum,
+		COALESCE(count(*), 0) as count
+	FROM blocks_withdrawals w
+	INNER JOIN blocks b ON b.blockroot = w.block_root AND b.status = '1' 
+	WHERE w.validatorindex = ANY($1) GROUP BY w.validatorindex
+	ORDER BY w.validatorindex`, pq.Array(validators))
+	return totalwithdrawals, err
+}
+
 func GetValidatorWithdrawalsCount(validator uint64) (count, lastWithdrawalEpoch uint64, err error) {
 
 	type dbResponse struct {

--- a/types/api.go
+++ b/types/api.go
@@ -159,3 +159,11 @@ type ApiValidatorWithdrawalResponse struct {
 	Address        string `json:"address"`
 	Amount         uint64 `json:"amount"`
 }
+
+type ApiValidatorTotalWithdrawalResponse struct {
+	Epoch          uint64 `json:"epoch,omitempty"`
+	Slot           uint64 `json:"slot,omitempty"`
+	ValidatorIndex uint64 `json:"validatorindex"`
+	Sum            uint64 `json:"sum"`
+	Count          uint64 `json:"count"`
+}

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -173,6 +173,13 @@ type Withdrawals struct {
 	Amount         uint64 `json:"amount"`
 }
 
+type TotalWithdrawals struct {
+	Slot           uint64 `json:"slot,omitempty"`
+	ValidatorIndex uint64 `json:"validatorindex"`
+	Sum            uint64 `json:"sum"`
+	Count          uint64 `json:"count"`
+}
+
 type WithdrawalsByEpoch struct {
 	Epoch          uint64
 	ValidatorIndex uint64


### PR DESCRIPTION
Adds an entry point that returns the sum of the verifiers' withdrawals.
This is to enable us to calculate the rewards of the validator being withdrawn


Related to https://github.com/bosagora/agora-chain/issues/44