### PR TITLE
검증자의 잔고를 매 슬롯마다 저장하도록 기능을 추가함

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -724,7 +724,7 @@ func SaveEpoch(data *types.EpochData) error {
 		return fmt.Errorf("error saving validator attestation assignments to db: %w", err)
 	}
 
-	withdrawals, err := getTotalWithdrawals(data.Epoch)
+	withdrawals, err := getTotalWithdrawalsByEpoch(data.Epoch)
 	if err != nil {
 		return fmt.Errorf("error get total withdrawals to db: %w", err)
 	}
@@ -834,6 +834,70 @@ func SaveEpoch(data *types.EpochData) error {
 	}
 
 	logger.Infof("export of epoch %v completed, took %v", data.Epoch, time.Since(start))
+	return nil
+}
+
+// SaveEpoch will save the epoch data into the database
+func SaveSlot(data *types.SlotData) error {
+	start := time.Now()
+	defer func() {
+		metrics.TaskDuration.WithLabelValues("db_save_epoch").Observe(time.Since(start).Seconds())
+		logger.WithFields(logrus.Fields{"epoch": data.Epoch, "duration": time.Since(start)}).Info("completed saving epoch")
+	}()
+
+	tx, err := WriterDb.Begin()
+	if err != nil {
+		return fmt.Errorf("error starting db transactions: %w", err)
+	}
+	defer tx.Rollback()
+
+	logger.WithFields(logrus.Fields{"chainSlot": utils.TimeToSlot(uint64(time.Now().Unix())), "exportSlot": data.Slot}).Infof("starting export of slot %v", data.Slot)
+
+	logger.Infof("exporting block data")
+	err = saveBlocks(data.Blocks, tx)
+	if err != nil {
+		logger.Fatalf("error saving blocks to db: %v", err)
+		return fmt.Errorf("error saving blocks to db: %w", err)
+	}
+
+	if uint64(utils.TimeToEpoch(time.Now())) > data.Epoch+100_000 {
+		logger.WithFields(logrus.Fields{"exportEpoch": data.Epoch, "chainEpoch": utils.TimeToEpoch(time.Now())}).Infof("skipping exporting validators because epoch is far behind head")
+	} else {
+		logger.Infof("exporting validators")
+		err = saveValidatorsInSlot(data, tx)
+		if err != nil {
+			return fmt.Errorf("error saving validators to db: %w", err)
+		}
+	}
+
+	withdrawals, err := getTotalWithdrawalsBySlot(data.Slot)
+	if err != nil {
+		return fmt.Errorf("error get total withdrawals to db: %w", err)
+	}
+
+	logger.Infof("exporting validator balance data")
+	err = saveValidatorBalances(data.Epoch, data.Validators, tx, withdrawals)
+	if err != nil {
+		return fmt.Errorf("error saving validator balances to db: %w", err)
+	}
+
+	// only export recent validator balances if the epoch is within the threshold
+	if uint64(utils.TimeToEpoch(time.Now())) > data.Epoch+100_000 {
+		logger.WithFields(logrus.Fields{"exportEpoch": data.Epoch, "chainEpoch": utils.TimeToEpoch(time.Now())}).Infof("skipping exporting recent validator balance because epoch is far behind head")
+	} else {
+		logger.Infof("exporting recent validator balance")
+		err = saveValidatorBalancesRecent(data.Epoch, data.Validators, tx, withdrawals)
+		if err != nil {
+			return fmt.Errorf("error saving recent validator balances to db: %w", err)
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("error committing db transaction: %w", err)
+	}
+
+	logger.Infof("export of slot %v completed, took %v", data.Slot, time.Since(start))
 	return nil
 }
 
@@ -1068,6 +1132,173 @@ func saveValidators(data *types.EpochData, tx *sql.Tx) error {
 	return nil
 }
 
+func saveValidatorsInSlot(data *types.SlotData, tx *sql.Tx) error {
+	start := time.Now()
+	defer func() {
+		metrics.TaskDuration.WithLabelValues("db_save_validators").Observe(time.Since(start).Seconds())
+	}()
+
+	validators := data.Validators
+
+	validatorsByIndex := make(map[uint64]*types.Validator, len(data.Validators))
+	for _, v := range data.Validators {
+		validatorsByIndex[v.Index] = v
+	}
+	slots := make([]uint64, 0, len(data.Blocks))
+	for slot := range data.Blocks {
+		slots = append(slots, slot)
+	}
+	sort.Slice(slots, func(i, j int) bool {
+		return slots[i] < slots[j]
+	})
+	for _, slot := range slots {
+		for _, b := range data.Blocks[slot] {
+			if !b.Canonical {
+				continue
+			}
+			propVal := validatorsByIndex[b.Proposer]
+			if propVal != nil {
+				propVal.LastProposalSlot = b.Slot
+			}
+			for _, a := range b.Attestations {
+				for _, v := range a.Attesters {
+					attVal := validatorsByIndex[v]
+					if attVal != nil {
+						attVal.LastAttestationSlot = a.Data.Slot
+					}
+				}
+			}
+		}
+	}
+
+	var latestBlock uint64
+	err := WriterDb.Get(&latestBlock, "SELECT COALESCE(MAX(slot), 0) FROM blocks WHERE status = '1'")
+	if err != nil {
+		return err
+	}
+
+	thresholdSlot := latestBlock - 64
+	if latestBlock < 64 {
+		thresholdSlot = 0
+	}
+
+	latestEpoch := latestBlock / 32
+	farFutureEpoch := uint64(18446744073709551615)
+	maxSqlNumber := uint64(9223372036854775807)
+
+	for _, v := range validators {
+		if v.WithdrawableEpoch == farFutureEpoch {
+			v.WithdrawableEpoch = maxSqlNumber
+		}
+		if v.ExitEpoch == farFutureEpoch {
+			v.ExitEpoch = maxSqlNumber
+		}
+		if v.ActivationEligibilityEpoch == farFutureEpoch {
+			v.ActivationEligibilityEpoch = maxSqlNumber
+		}
+		if v.ActivationEpoch == farFutureEpoch {
+			v.ActivationEpoch = maxSqlNumber
+		}
+	}
+
+	batchSize := 4000 // max parameters: 65535
+	for b := 0; b < len(validators); b += batchSize {
+		start := b
+		end := b + batchSize
+		if len(validators) < end {
+			end = len(validators)
+		}
+
+		numArgs := 16
+		valueStrings := make([]string, 0, batchSize)
+		valueArgs := make([]interface{}, 0, batchSize*numArgs)
+		for i, v := range validators[start:end] {
+			valueStrings = append(valueStrings, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)", i*numArgs+1, i*numArgs+2, i*numArgs+3, i*numArgs+4, i*numArgs+5, i*numArgs+6, i*numArgs+7, i*numArgs+8, i*numArgs+9, i*numArgs+10, i*numArgs+11, i*numArgs+12, i*numArgs+13, i*numArgs+14, i*numArgs+15, i*numArgs+16))
+			valueArgs = append(valueArgs, v.Index)
+			valueArgs = append(valueArgs, v.PublicKey)
+			valueArgs = append(valueArgs, v.WithdrawableEpoch)
+			valueArgs = append(valueArgs, v.WithdrawalCredentials)
+			valueArgs = append(valueArgs, v.Balance)
+			valueArgs = append(valueArgs, v.EffectiveBalance)
+			valueArgs = append(valueArgs, v.Slashed)
+			valueArgs = append(valueArgs, v.ActivationEligibilityEpoch)
+			valueArgs = append(valueArgs, v.ActivationEpoch)
+			valueArgs = append(valueArgs, v.ExitEpoch)
+			valueArgs = append(valueArgs, v.Balance1d)
+			valueArgs = append(valueArgs, v.Balance7d)
+			valueArgs = append(valueArgs, v.Balance31d)
+			valueArgs = append(valueArgs, fmt.Sprintf("%x", v.PublicKey))
+			valueArgs = append(valueArgs, v.Status)
+			valueArgs = append(valueArgs, v.LastAttestationSlot)
+		}
+		stmt := fmt.Sprintf(`
+			INSERT INTO validators (
+				validatorindex,
+				pubkey,
+				withdrawableepoch,
+				withdrawalcredentials,
+				balance,
+				effectivebalance,
+				slashed,
+				activationeligibilityepoch,
+				activationepoch,
+				exitepoch,
+				balance1d,
+				balance7d,
+				balance31d,
+				pubkeyhex,
+				status,
+				lastattestationslot
+			)
+			VALUES %[3]s
+			ON CONFLICT (validatorindex) DO UPDATE SET
+				withdrawableepoch          = EXCLUDED.withdrawableepoch,
+				balance                    = EXCLUDED.balance,
+				effectivebalance           = EXCLUDED.effectivebalance,
+				slashed                    = EXCLUDED.slashed,
+				activationeligibilityepoch = EXCLUDED.activationeligibilityepoch,
+				activationepoch            = EXCLUDED.activationepoch,
+				exitepoch                  = EXCLUDED.exitepoch,
+				balance1d                  = EXCLUDED.balance1d,
+				balance7d                  = EXCLUDED.balance7d,
+				balance31d                 = EXCLUDED.balance31d,
+				lastattestationslot        =
+					CASE
+					WHEN EXCLUDED.lastattestationslot > COALESCE(validators.lastattestationslot, 0) THEN EXCLUDED.lastattestationslot
+					ELSE validators.lastattestationslot
+					END,
+				status                     =
+					CASE
+					WHEN EXCLUDED.exitepoch <= %[1]d AND EXCLUDED.slashed THEN 'slashed'
+					WHEN EXCLUDED.exitepoch <= %[1]d THEN 'exited'
+					WHEN EXCLUDED.activationeligibilityepoch = 9223372036854775807 THEN 'deposited'
+					WHEN EXCLUDED.activationepoch > %[1]d THEN 'pending'
+					WHEN EXCLUDED.slashed AND EXCLUDED.activationepoch < %[1]d AND GREATEST(EXCLUDED.lastattestationslot, validators.lastattestationslot) < %[2]d THEN 'slashing_offline'
+					WHEN EXCLUDED.slashed THEN 'slashing_online'
+					WHEN EXCLUDED.exitepoch < 9223372036854775807 AND GREATEST(EXCLUDED.lastattestationslot, validators.lastattestationslot) < %[2]d THEN 'exiting_offline'
+					WHEN EXCLUDED.exitepoch < 9223372036854775807 THEN 'exiting_online'
+					WHEN EXCLUDED.activationepoch < %[1]d AND GREATEST(EXCLUDED.lastattestationslot, validators.lastattestationslot) < %[2]d THEN 'active_offline'
+					ELSE 'active_online'
+					END`,
+			latestEpoch, thresholdSlot, strings.Join(valueStrings, ","))
+		_, err := tx.Exec(stmt, valueArgs...)
+		if err != nil {
+			return err
+		}
+
+		logger.Infof("saving validator batch %v completed", b)
+	}
+
+	s := time.Now()
+	_, err = tx.Exec("update validators set balanceactivation = (select balance from validator_balances_p where validator_balances_p.week = validators.activationepoch / 1575 and validator_balances_p.epoch = validators.activationepoch and validator_balances_p.validatorindex = validators.validatorindex) WHERE balanceactivation IS NULL;")
+	if err != nil {
+		return err
+	}
+	logger.Infof("updating validator activation epoch balance completed, took %v", time.Since(s))
+
+	return nil
+}
+
 func saveValidatorProposalAssignments(epoch uint64, assignments map[uint64]uint64, tx *sql.Tx) error {
 	start := time.Now()
 	defer func() {
@@ -1135,7 +1366,7 @@ func saveValidatorAttestationAssignments(epoch uint64, assignments map[string]ui
 	return nil
 }
 
-func getTotalWithdrawals(epoch uint64) (map[uint64]uint64, error) {
+func getTotalWithdrawalsByEpoch(epoch uint64) (map[uint64]uint64, error) {
 	withdrawals := make(map[uint64]uint64)
 	var rows []struct {
 		ValidatorIndex uint64
@@ -1147,6 +1378,28 @@ func getTotalWithdrawals(epoch uint64) (map[uint64]uint64, error) {
 		FROM blocks_withdrawals w
 		INNER JOIN blocks b ON b.blockroot = w.block_root AND b.status = '1' 
 		WHERE w.block_slot/$1 <= $2 GROUP BY w.validatorindex`, utils.Config.Chain.Config.SlotsPerEpoch, epoch)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		withdrawals[row.ValidatorIndex] = row.Amount
+	}
+
+	return withdrawals, nil
+}
+
+func getTotalWithdrawalsBySlot(slot uint64) (map[uint64]uint64, error) {
+	withdrawals := make(map[uint64]uint64)
+	var rows []struct {
+		ValidatorIndex uint64
+		Amount         uint64
+	}
+
+	err := WriterDb.Select(&rows, `
+		SELECT w.validatorindex, SUM(w.amount) AS amount 
+		FROM blocks_withdrawals w
+		INNER JOIN blocks b ON b.blockroot = w.block_root AND b.status = '1' 
+		WHERE w.block_slot <= $1 GROUP BY w.validatorindex`, slot)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"eth2-exporter/types"
@@ -878,6 +877,136 @@ func (lc *LighthouseClient) GetSyncCommittee(stateID string, epoch uint64) (*Sta
 	return &parsedSyncCommittees.Data, nil
 }
 
+// GetSlotData will get the slot data
+func (lc *LighthouseClient) GetSlotData(block *types.Block) (*types.SlotData, error) {
+	wg := &sync.WaitGroup{}
+	var err error
+
+	slot := utils.EpochOfSlot(block.Slot)
+	epoch := utils.EpochOfSlot(slot)
+	data := &types.SlotData{}
+	data.Epoch = epoch
+	data.Slot = slot
+
+	validatorsResp, err := lc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validators", lc.endpoint, slot))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving validators for slot %v: %v", slot, err)
+	}
+	var parsedValidators StandardValidatorsResponse
+	err = json.Unmarshal(validatorsResp, &parsedValidators)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing epoch validators: %v", err)
+	}
+
+	slot1d := int64(slot) - 7200
+	slot7d := int64(slot) - 7200*7
+	slot31d := int64(slot) - 7200*31
+
+	var validatorBalances1d map[uint64]uint64
+	var validatorBalances7d map[uint64]uint64
+	var validatorBalances31d map[uint64]uint64
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances1d, err = lc.GetBalancesForSlot(slot1d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (1d): %v", slot1d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (1d) took %v", len(parsedValidators.Data), slot1d, time.Since(start))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances7d, err = lc.GetBalancesForSlot(slot7d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (7d): %v", slot7d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (7d) took %v", len(parsedValidators.Data), slot7d, time.Since(start))
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances31d, err = lc.GetBalancesForSlot(slot31d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (31d): %v", slot31d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (31d) took %v", len(parsedValidators.Data), slot31d, time.Since(start))
+	}()
+	wg.Wait()
+
+	// Retrieve a block for the slot
+	data.Blocks = make(map[uint64]map[string]*types.Block)
+	if data.Blocks[block.Slot] == nil {
+		data.Blocks[block.Slot] = make(map[string]*types.Block)
+	}
+	data.Blocks[block.Slot][fmt.Sprintf("%x", block.BlockRoot)] = block
+	logger.Printf("retrieved a block for slot %v", slot)
+
+	// Retrieve the validator set for the slot
+	data.Validators = make([]*types.Validator, 0)
+
+	for _, validator := range parsedValidators.Data {
+		data.Validators = append(data.Validators, &types.Validator{
+			Index:                      uint64(validator.Index),
+			PublicKey:                  utils.MustParseHex(validator.Validator.Pubkey),
+			WithdrawalCredentials:      utils.MustParseHex(validator.Validator.WithdrawalCredentials),
+			Balance:                    uint64(validator.Balance),
+			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+			Slashed:                    validator.Validator.Slashed,
+			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+			Balance1d:                  validatorBalances1d[uint64(validator.Index)],
+			Balance7d:                  validatorBalances7d[uint64(validator.Index)],
+			Balance31d:                 validatorBalances31d[uint64(validator.Index)],
+			Status:                     validator.Status,
+		})
+	}
+
+	logger.Printf("retrieved data for %v validators for slot %v", len(data.Validators), slot)
+
+	return data, nil
+}
+
+func (lc *LighthouseClient) GetBalancesForSlot(slot int64) (map[uint64]uint64, error) {
+	if slot < 0 {
+		slot = 0
+	}
+
+	var err error
+
+	validatorBalances := make(map[uint64]uint64)
+
+	resp, err := lc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validator_balances", lc.endpoint, slot))
+	if err != nil {
+		return validatorBalances, err
+	}
+
+	var parsedResponse StandardValidatorBalancesResponse
+	err = json.Unmarshal(resp, &parsedResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response for validator_balances")
+	}
+
+	for _, b := range parsedResponse.Data {
+		validatorBalances[uint64(b.Index)] = uint64(b.Balance)
+	}
+
+	return validatorBalances, nil
+}
+
 var notFoundErr = errors.New("not found 404")
 
 func (lc *LighthouseClient) get(url string) ([]byte, error) {
@@ -901,324 +1030,4 @@ func (lc *LighthouseClient) get(url string) ([]byte, error) {
 	}
 
 	return data, err
-}
-
-type bytesHexStr []byte
-
-func (s *bytesHexStr) UnmarshalText(b []byte) error {
-	if s == nil {
-		return fmt.Errorf("cannot unmarshal bytes into nil")
-	}
-	if len(b) >= 2 && b[0] == '0' && b[1] == 'x' {
-		b = b[2:]
-	}
-	out := make([]byte, len(b)/2, len(b)/2)
-	hex.Decode(out, b)
-	*s = out
-	return nil
-}
-
-type uint64Str uint64
-
-func (s *uint64Str) UnmarshalJSON(b []byte) error {
-	return Uint64Unmarshal((*uint64)(s), b)
-}
-
-// Parse a uint64, with or without quotes, in any base, with common prefixes accepted to change base.
-func Uint64Unmarshal(v *uint64, b []byte) error {
-	if v == nil {
-		return errors.New("nil dest in uint64 decoding")
-	}
-	if len(b) == 0 {
-		return errors.New("empty uint64 input")
-	}
-	if b[0] == '"' || b[0] == '\'' {
-		if len(b) == 1 || b[len(b)-1] != b[0] {
-			return errors.New("uneven/missing quotes")
-		}
-		b = b[1 : len(b)-1]
-	}
-	n, err := strconv.ParseUint(string(b), 0, 64)
-	if err != nil {
-		return err
-	}
-	*v = n
-	return nil
-}
-
-type StandardBeaconHeaderResponse struct {
-	Data struct {
-		Root      string `json:"root"`
-		Canonical bool   `json:"canonical"`
-		Header    struct {
-			Message struct {
-				Slot          uint64Str `json:"slot"`
-				ProposerIndex uint64Str `json:"proposer_index"`
-				ParentRoot    string    `json:"parent_root"`
-				StateRoot     string    `json:"state_root"`
-				BodyRoot      string    `json:"body_root"`
-			} `json:"message"`
-			Signature string `json:"signature"`
-		} `json:"header"`
-	} `json:"data"`
-}
-
-type StandardFinalityCheckpointsResponse struct {
-	Data struct {
-		PreviousJustified struct {
-			Epoch uint64Str `json:"epoch"`
-			Root  string    `json:"root"`
-		} `json:"previous_justified"`
-		CurrentJustified struct {
-			Epoch uint64Str `json:"epoch"`
-			Root  string    `json:"root"`
-		} `json:"current_justified"`
-		Finalized struct {
-			Epoch uint64Str `json:"epoch"`
-			Root  string    `json:"root"`
-		} `json:"finalized"`
-	} `json:"data"`
-}
-
-type StandardProposerDuty struct {
-	Pubkey         string    `json:"pubkey"`
-	ValidatorIndex uint64Str `json:"validator_index"`
-	Slot           uint64Str `json:"slot"`
-}
-
-type StandardProposerDutiesResponse struct {
-	DependentRoot string                 `json:"dependent_root"`
-	Data          []StandardProposerDuty `json:"data"`
-}
-
-type StandardCommitteeEntry struct {
-	Index      uint64Str `json:"index"`
-	Slot       uint64Str `json:"slot"`
-	Validators []string  `json:"validators"`
-}
-
-type StandardCommitteesResponse struct {
-	Data []StandardCommitteeEntry `json:"data"`
-}
-
-type StandardSyncCommittee struct {
-	Validators          []string   `json:"validators"`
-	ValidatorAggregates [][]string `json:"validator_aggregates"`
-}
-
-type StandardSyncCommitteesResponse struct {
-	Data StandardSyncCommittee `json:"data"`
-}
-
-type LighthouseValidatorParticipationResponse struct {
-	Data struct {
-		CurrentEpochActiveGwei           uint64Str `json:"current_epoch_active_gwei"`
-		PreviousEpochActiveGwei          uint64Str `json:"previous_epoch_active_gwei"`
-		CurrentEpochTargetAttestingGwei  uint64Str `json:"current_epoch_target_attesting_gwei"`
-		PreviousEpochTargetAttestingGwei uint64Str `json:"previous_epoch_target_attesting_gwei"`
-		PreviousEpochHeadAttestingGwei   uint64Str `json:"previous_epoch_head_attesting_gwei"`
-	} `json:"data"`
-}
-
-type ProposerSlashing struct {
-	SignedHeader1 struct {
-		Message struct {
-			Slot          uint64Str `json:"slot"`
-			ProposerIndex uint64Str `json:"proposer_index"`
-			ParentRoot    string    `json:"parent_root"`
-			StateRoot     string    `json:"state_root"`
-			BodyRoot      string    `json:"body_root"`
-		} `json:"message"`
-		Signature string `json:"signature"`
-	} `json:"signed_header_1"`
-	SignedHeader2 struct {
-		Message struct {
-			Slot          uint64Str `json:"slot"`
-			ProposerIndex uint64Str `json:"proposer_index"`
-			ParentRoot    string    `json:"parent_root"`
-			StateRoot     string    `json:"state_root"`
-			BodyRoot      string    `json:"body_root"`
-		} `json:"message"`
-		Signature string `json:"signature"`
-	} `json:"signed_header_2"`
-}
-
-type AttesterSlashing struct {
-	Attestation1 struct {
-		AttestingIndices []uint64Str `json:"attesting_indices"`
-		Signature        string      `json:"signature"`
-		Data             struct {
-			Slot            uint64Str `json:"slot"`
-			Index           uint64Str `json:"index"`
-			BeaconBlockRoot string    `json:"beacon_block_root"`
-			Source          struct {
-				Epoch uint64Str `json:"epoch"`
-				Root  string    `json:"root"`
-			} `json:"source"`
-			Target struct {
-				Epoch uint64Str `json:"epoch"`
-				Root  string    `json:"root"`
-			} `json:"target"`
-		} `json:"data"`
-	} `json:"attestation_1"`
-	Attestation2 struct {
-		AttestingIndices []uint64Str `json:"attesting_indices"`
-		Signature        string      `json:"signature"`
-		Data             struct {
-			Slot            uint64Str `json:"slot"`
-			Index           uint64Str `json:"index"`
-			BeaconBlockRoot string    `json:"beacon_block_root"`
-			Source          struct {
-				Epoch uint64Str `json:"epoch"`
-				Root  string    `json:"root"`
-			} `json:"source"`
-			Target struct {
-				Epoch uint64Str `json:"epoch"`
-				Root  string    `json:"root"`
-			} `json:"target"`
-		} `json:"data"`
-	} `json:"attestation_2"`
-}
-
-type Attestation struct {
-	AggregationBits string `json:"aggregation_bits"`
-	Signature       string `json:"signature"`
-	Data            struct {
-		Slot            uint64Str `json:"slot"`
-		Index           uint64Str `json:"index"`
-		BeaconBlockRoot string    `json:"beacon_block_root"`
-		Source          struct {
-			Epoch uint64Str `json:"epoch"`
-			Root  string    `json:"root"`
-		} `json:"source"`
-		Target struct {
-			Epoch uint64Str `json:"epoch"`
-			Root  string    `json:"root"`
-		} `json:"target"`
-	} `json:"data"`
-}
-
-type Deposit struct {
-	Proof []string `json:"proof"`
-	Data  struct {
-		Pubkey                string    `json:"pubkey"`
-		WithdrawalCredentials string    `json:"withdrawal_credentials"`
-		Amount                uint64Str `json:"amount"`
-		Signature             string    `json:"signature"`
-	} `json:"data"`
-}
-
-type VoluntaryExit struct {
-	Message struct {
-		Epoch          uint64Str `json:"epoch"`
-		ValidatorIndex uint64Str `json:"validator_index"`
-	} `json:"message"`
-	Signature string `json:"signature"`
-}
-
-type Eth1Data struct {
-	DepositRoot  string    `json:"deposit_root"`
-	DepositCount uint64Str `json:"deposit_count"`
-	BlockHash    string    `json:"block_hash"`
-}
-
-type SyncAggregate struct {
-	SyncCommitteeBits      string `json:"sync_committee_bits"`
-	SyncCommitteeSignature string `json:"sync_committee_signature"`
-}
-
-// https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
-// https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#executionpayload
-type ExecutionPayload struct {
-	ParentHash    bytesHexStr   `json:"parent_hash"`
-	FeeRecipient  bytesHexStr   `json:"fee_recipient"`
-	StateRoot     bytesHexStr   `json:"state_root"`
-	ReceiptsRoot  bytesHexStr   `json:"receipts_root"`
-	LogsBloom     bytesHexStr   `json:"logs_bloom"`
-	PrevRandao    bytesHexStr   `json:"prev_randao"`
-	BlockNumber   uint64Str     `json:"block_number"`
-	GasLimit      uint64Str     `json:"gas_limit"`
-	GasUsed       uint64Str     `json:"gas_used"`
-	Timestamp     uint64Str     `json:"timestamp"`
-	ExtraData     bytesHexStr   `json:"extra_data"`
-	BaseFeePerGas uint64Str     `json:"base_fee_per_gas"`
-	BlockHash     bytesHexStr   `json:"block_hash"`
-	Transactions  []bytesHexStr `json:"transactions"`
-}
-
-type AnySignedBlock struct {
-	Message struct {
-		Slot          uint64Str `json:"slot"`
-		ProposerIndex uint64Str `json:"proposer_index"`
-		ParentRoot    string    `json:"parent_root"`
-		StateRoot     string    `json:"state_root"`
-		Body          struct {
-			RandaoReveal      string             `json:"randao_reveal"`
-			Eth1Data          Eth1Data           `json:"eth1_data"`
-			Graffiti          string             `json:"graffiti"`
-			ProposerSlashings []ProposerSlashing `json:"proposer_slashings"`
-			AttesterSlashings []AttesterSlashing `json:"attester_slashings"`
-			Attestations      []Attestation      `json:"attestations"`
-			Deposits          []Deposit          `json:"deposits"`
-			VoluntaryExits    []VoluntaryExit    `json:"voluntary_exits"`
-
-			// not present in phase0 blocks
-			SyncAggregate *SyncAggregate `json:"sync_aggregate,omitempty"`
-
-			// not present in phase0/altair blocks
-			ExecutionPayload *ExecutionPayload `json:"execution_payload"`
-		} `json:"body"`
-	} `json:"message"`
-	Signature bytesHexStr `json:"signature"`
-}
-
-type StandardV2BlockResponse struct {
-	Version string         `json:"version"`
-	Data    AnySignedBlock `json:"data"`
-}
-
-type StandardV1BlockRootResponse struct {
-	Data struct {
-		Root string `json:"root"`
-	} `json:"data"`
-}
-
-type StandardValidatorEntry struct {
-	Index     uint64Str `json:"index"`
-	Balance   uint64Str `json:"balance"`
-	Status    string    `json:"status"`
-	Validator struct {
-		Pubkey                     string    `json:"pubkey"`
-		WithdrawalCredentials      string    `json:"withdrawal_credentials"`
-		EffectiveBalance           uint64Str `json:"effective_balance"`
-		Slashed                    bool      `json:"slashed"`
-		ActivationEligibilityEpoch uint64Str `json:"activation_eligibility_epoch"`
-		ActivationEpoch            uint64Str `json:"activation_epoch"`
-		ExitEpoch                  uint64Str `json:"exit_epoch"`
-		WithdrawableEpoch          uint64Str `json:"withdrawable_epoch"`
-	} `json:"validator"`
-}
-
-type StandardValidatorsResponse struct {
-	Data []StandardValidatorEntry `json:"data"`
-}
-
-func (pc *LighthouseClient) GetBlockStatusByEpoch(epoch uint64) ([]*types.CanonBlock, error) {
-	blocks := make([]*types.CanonBlock, 0)
-	return blocks, nil
-}
-
-type StandardSyncingResponse struct {
-	Data struct {
-		IsSyncing    bool      `json:"is_syncing"`
-		HeadSlot     uint64Str `json:"head_slot"`
-		SyncDistance uint64Str `json:"sync_distance"`
-	} `json:"data"`
-}
-
-type StandardValidatorBalancesResponse struct {
-	Data []struct {
-		Index   uint64Str `json:"index"`
-		Balance uint64Str `json:"balance"`
-	} `json:"data"`
 }

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -306,7 +306,7 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64) (*types.EpochData, error)
 		defer wg.Done()
 		start := time.Now()
 		var err error
-		validatorBalances1d, err = lc.getBalancesForEpoch(epoch1d)
+		validatorBalances1d, err = lc.GetBalancesForEpoch(epoch1d)
 		if err != nil {
 			logrus.Errorf("error retrieving validator balances for epoch %v (1d): %v", epoch1d, err)
 			return
@@ -318,7 +318,7 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64) (*types.EpochData, error)
 		defer wg.Done()
 		start := time.Now()
 		var err error
-		validatorBalances7d, err = lc.getBalancesForEpoch(epoch7d)
+		validatorBalances7d, err = lc.GetBalancesForEpoch(epoch7d)
 		if err != nil {
 			logrus.Errorf("error retrieving validator balances for epoch %v (7d): %v", epoch7d, err)
 			return
@@ -330,7 +330,7 @@ func (lc *LighthouseClient) GetEpochData(epoch uint64) (*types.EpochData, error)
 		defer wg.Done()
 		start := time.Now()
 		var err error
-		validatorBalances31d, err = lc.getBalancesForEpoch(epoch31d)
+		validatorBalances31d, err = lc.GetBalancesForEpoch(epoch31d)
 		if err != nil {
 			logrus.Errorf("error retrieving validator balances for epoch %v (31d): %v", epoch31d, err)
 			return
@@ -467,7 +467,7 @@ func uint64List(li []uint64Str) []uint64 {
 	return out
 }
 
-func (lc *LighthouseClient) getBalancesForEpoch(epoch int64) (map[uint64]uint64, error) {
+func (lc *LighthouseClient) GetBalancesForEpoch(epoch int64) (map[uint64]uint64, error) {
 
 	if epoch < 0 {
 		epoch = 0

--- a/rpc/lighthouse.go
+++ b/rpc/lighthouse.go
@@ -477,7 +477,7 @@ func (lc *LighthouseClient) GetBalancesForEpoch(epoch int64) (map[uint64]uint64,
 
 	validatorBalances := make(map[uint64]uint64)
 
-	resp, err := lc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validator_balances", lc.endpoint, epoch*int64(utils.Config.Chain.Config.SlotsPerEpoch)))
+	resp, err := lc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validator_balances", lc.endpoint, (epoch+1)*int64(utils.Config.Chain.Config.SlotsPerEpoch)-1))
 	if err != nil {
 		return validatorBalances, err
 	}

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -9,6 +9,7 @@ import (
 	"eth2-exporter/types"
 	"eth2-exporter/utils"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -393,7 +394,10 @@ func (pc *PrysmClient) getBalancesForEpoch(epoch int64) (map[uint64]uint64, erro
 	validatorBalances := make(map[uint64]uint64)
 
 	validatorBalancesResponse := &ethpb.ValidatorBalances{}
-	validatorBalancesRequest := &ethpb.ListValidatorBalancesRequest{PageSize: utils.Config.Indexer.Node.PageSize, PageToken: validatorBalancesResponse.NextPageToken, QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: eth2types.Epoch(epoch)}}
+	validatorBalancesRequest := &ethpb.ListValidatorBalancesRequest{
+		PageSize:    utils.Config.Indexer.Node.PageSize,
+		PageToken:   validatorBalancesResponse.NextPageToken,
+		QueryFilter: &ethpb.ListValidatorBalancesRequest_Epoch{Epoch: eth2types.Epoch(epoch)}}
 	if epoch == 0 {
 		validatorBalancesRequest.QueryFilter = &ethpb.ListValidatorBalancesRequest_Genesis{Genesis: true}
 	}
@@ -1309,6 +1313,136 @@ func (pc *PrysmClient) GetSyncCommittee(stateID string, epoch uint64) (*Standard
 		return nil, fmt.Errorf("error parsing sync_committees data for epoch %v (state: %v): %w", epoch, stateID, err)
 	}
 	return &parsedSyncCommittees.Data, nil
+}
+
+// GetSlotData will get the slot data from a Prysm client
+func (pc *PrysmClient) GetSlotData(block *types.Block) (*types.SlotData, error) {
+	wg := &sync.WaitGroup{}
+	var err error
+
+	slot := block.Slot
+	epoch := utils.EpochOfSlot(slot)
+	data := &types.SlotData{}
+	data.Epoch = epoch
+	data.Slot = slot
+
+	validatorsResp, err := pc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validators", pc.endpoint, slot))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving validators for slot %v: %v", slot, err)
+	}
+	var parsedValidators StandardValidatorsResponse
+	err = json.Unmarshal(validatorsResp, &parsedValidators)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing epoch validators: %v", err)
+	}
+
+	slot1d := int64(slot) - 7200
+	slot7d := int64(slot) - 7200*7
+	slot31d := int64(slot) - 7200*31
+
+	var validatorBalances1d map[uint64]uint64
+	var validatorBalances7d map[uint64]uint64
+	var validatorBalances31d map[uint64]uint64
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances1d, err = pc.GetBalancesForSlot(slot1d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (1d): %v", slot1d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (1d) took %v", len(parsedValidators.Data), slot1d, time.Since(start))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances7d, err = pc.GetBalancesForSlot(slot7d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (7d): %v", slot7d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (7d) took %v", len(parsedValidators.Data), slot7d, time.Since(start))
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances31d, err = pc.GetBalancesForSlot(slot31d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (31d): %v", slot31d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (31d) took %v", len(parsedValidators.Data), slot31d, time.Since(start))
+	}()
+	wg.Wait()
+
+	// Retrieve a block for the slot
+	data.Blocks = make(map[uint64]map[string]*types.Block)
+	if data.Blocks[block.Slot] == nil {
+		data.Blocks[block.Slot] = make(map[string]*types.Block)
+	}
+	data.Blocks[block.Slot][fmt.Sprintf("%x", block.BlockRoot)] = block
+	logger.Printf("retrieved a block for slot %v", slot)
+
+	// Retrieve the validator set for the slot
+	data.Validators = make([]*types.Validator, 0)
+
+	for _, validator := range parsedValidators.Data {
+		data.Validators = append(data.Validators, &types.Validator{
+			Index:                      uint64(validator.Index),
+			PublicKey:                  utils.MustParseHex(validator.Validator.Pubkey),
+			WithdrawalCredentials:      utils.MustParseHex(validator.Validator.WithdrawalCredentials),
+			Balance:                    uint64(validator.Balance),
+			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+			Slashed:                    validator.Validator.Slashed,
+			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+			Balance1d:                  validatorBalances1d[uint64(validator.Index)],
+			Balance7d:                  validatorBalances7d[uint64(validator.Index)],
+			Balance31d:                 validatorBalances31d[uint64(validator.Index)],
+			Status:                     validator.Status,
+		})
+	}
+
+	logger.Printf("retrieved data for %v validators for slot %v", len(data.Validators), slot)
+
+	return data, nil
+}
+
+func (pc *PrysmClient) GetBalancesForSlot(slot int64) (map[uint64]uint64, error) {
+	if slot < 0 {
+		slot = 0
+	}
+
+	var err error
+
+	validatorBalances := make(map[uint64]uint64)
+
+	resp, err := pc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validator_balances", pc.endpoint, slot))
+	if err != nil {
+		return validatorBalances, err
+	}
+
+	var parsedResponse StandardValidatorBalancesResponse
+	err = json.Unmarshal(resp, &parsedResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response for validator_balances")
+	}
+
+	for _, b := range parsedResponse.Data {
+		validatorBalances[uint64(b.Index)] = uint64(b.Balance)
+	}
+
+	return validatorBalances, nil
 }
 
 func (pc *PrysmClient) get(url string) ([]byte, error) {

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -239,25 +239,25 @@ func (pc *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 
 	// Retrieve the validator balances for the requested epoch
 	start := time.Now()
-	validatorBalances, _ := pc.getBalancesForEpoch(int64(epoch))
+	validatorBalances, _ := pc.GetBalancesForEpoch(int64(epoch))
 	logger.Printf("retrieved data for %v validator balances for epoch %v took %v", len(validatorBalances), epoch, time.Since(start))
 
 	// Retrieve the validator balances for the n-1d epoch
 	start = time.Now()
 	epoch1d := int64(epoch) - 225
-	validatorBalances1d, _ := pc.getBalancesForEpoch(epoch1d)
+	validatorBalances1d, _ := pc.GetBalancesForEpoch(epoch1d)
 	logger.Printf("retrieved data for %v validator balances for 1d epoch %v took %v", len(validatorBalances), epoch1d, time.Since(start))
 
 	// Retrieve the validator balances for the n-7d epoch
 	start = time.Now()
 	epoch7d := int64(epoch) - 225*7
-	validatorBalances7d, _ := pc.getBalancesForEpoch(epoch7d)
+	validatorBalances7d, _ := pc.GetBalancesForEpoch(epoch7d)
 	logger.Printf("retrieved data for %v validator balances for 7d epoch %v took %v", len(validatorBalances), epoch7d, time.Since(start))
 
 	// Retrieve the validator balances for the n-7d epoch
 	start = time.Now()
 	epoch31d := int64(epoch) - 225*31
-	validatorBalances31d, _ := pc.getBalancesForEpoch(epoch31d)
+	validatorBalances31d, _ := pc.GetBalancesForEpoch(epoch31d)
 	logger.Printf("retrieved data for %v validator balances for 31d epoch %v took %v", len(validatorBalances), epoch31d, time.Since(start))
 
 	data.ValidatorAssignmentes, err = pc.GetEpochAssignments(epoch)
@@ -383,7 +383,7 @@ func (pc *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 	return data, nil
 }
 
-func (pc *PrysmClient) getBalancesForEpoch(epoch int64) (map[uint64]uint64, error) {
+func (pc *PrysmClient) GetBalancesForEpoch(epoch int64) (map[uint64]uint64, error) {
 
 	if epoch < 0 {
 		epoch = 0

--- a/rpc/prysm.go
+++ b/rpc/prysm.go
@@ -40,6 +40,8 @@ type PrysmClient struct {
 	signer              gtypes.Signer
 }
 
+var PrysmLatestHeadSlot uint64 = 0
+
 // NewPrysmClient is used for a new Prysm client connection
 func NewPrysmClient(grpcEndpoint string, rpcEndpoint string, chainId *big.Int) (*PrysmClient, error) {
 	dialOpts := []grpc.DialOption{
@@ -232,33 +234,78 @@ func (pc *PrysmClient) GetEpochAssignments(epoch uint64) (*types.EpochAssignment
 
 // GetEpochData will get the epoch data from a Prysm client
 func (pc *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
+	wg := &sync.WaitGroup{}
 	var err error
 
 	data := &types.EpochData{}
 	data.Epoch = epoch
 
-	// Retrieve the validator balances for the requested epoch
-	start := time.Now()
-	validatorBalances, _ := pc.GetBalancesForEpoch(int64(epoch))
-	logger.Printf("retrieved data for %v validator balances for epoch %v took %v", len(validatorBalances), epoch, time.Since(start))
+	var lastSlot uint64
+	if PrysmLatestHeadSlot == 0 {
+		lastSlot = epoch * utils.Config.Chain.Config.SlotsPerEpoch
+	} else {
+		lastSlot = (epoch+1)*utils.Config.Chain.Config.SlotsPerEpoch - 1
+		if PrysmLatestHeadSlot < lastSlot {
+			lastSlot = PrysmLatestHeadSlot
+		}
+	}
 
-	// Retrieve the validator balances for the n-1d epoch
-	start = time.Now()
-	epoch1d := int64(epoch) - 225
-	validatorBalances1d, _ := pc.GetBalancesForEpoch(epoch1d)
-	logger.Printf("retrieved data for %v validator balances for 1d epoch %v took %v", len(validatorBalances), epoch1d, time.Since(start))
+	validatorsResp, err := pc.get(fmt.Sprintf("%s/eth/v1/beacon/states/%d/validators", pc.endpoint, lastSlot))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving validators for slot %v: %v", lastSlot, err)
+	}
+	var parsedValidators StandardValidatorsResponse
+	err = json.Unmarshal(validatorsResp, &parsedValidators)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing epoch validators: %v", err)
+	}
 
-	// Retrieve the validator balances for the n-7d epoch
-	start = time.Now()
-	epoch7d := int64(epoch) - 225*7
-	validatorBalances7d, _ := pc.GetBalancesForEpoch(epoch7d)
-	logger.Printf("retrieved data for %v validator balances for 7d epoch %v took %v", len(validatorBalances), epoch7d, time.Since(start))
+	slot1d := int64(lastSlot) - 7200
+	slot7d := int64(lastSlot) - 7200*7
+	slot31d := int64(lastSlot) - 7200*31
 
-	// Retrieve the validator balances for the n-7d epoch
-	start = time.Now()
-	epoch31d := int64(epoch) - 225*31
-	validatorBalances31d, _ := pc.GetBalancesForEpoch(epoch31d)
-	logger.Printf("retrieved data for %v validator balances for 31d epoch %v took %v", len(validatorBalances), epoch31d, time.Since(start))
+	var validatorBalances1d map[uint64]uint64
+	var validatorBalances7d map[uint64]uint64
+	var validatorBalances31d map[uint64]uint64
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances1d, err = pc.GetBalancesForSlot(slot1d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (1d): %v", slot1d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (1d) took %v", len(parsedValidators.Data), slot1d, time.Since(start))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances7d, err = pc.GetBalancesForSlot(slot7d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (7d): %v", slot7d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (7d) took %v", len(parsedValidators.Data), slot7d, time.Since(start))
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		var err error
+		validatorBalances31d, err = pc.GetBalancesForSlot(slot31d)
+		if err != nil {
+			logrus.Errorf("error retrieving validator balances for slot %v (31d): %v", slot31d, err)
+			return
+		}
+		logger.Printf("retrieved data for %v validator balances for slot %v (31d) took %v", len(parsedValidators.Data), slot31d, time.Since(start))
+	}()
+	wg.Wait()
 
 	data.ValidatorAssignmentes, err = pc.GetEpochAssignments(epoch)
 	if err != nil {
@@ -324,54 +371,24 @@ func (pc *PrysmClient) GetEpochData(epoch uint64) (*types.EpochData, error) {
 
 	// Retrieve the validator set for the epoch
 	data.Validators = make([]*types.Validator, 0)
-	validatorResponse := &ethpb.Validators{}
-	validatorRequest := &ethpb.ListValidatorsRequest{PageToken: validatorResponse.NextPageToken, PageSize: utils.Config.Indexer.Node.PageSize, QueryFilter: &ethpb.ListValidatorsRequest_Epoch{Epoch: eth2types.Epoch(epoch)}}
-	if epoch == 0 {
-		validatorRequest.QueryFilter = &ethpb.ListValidatorsRequest_Genesis{Genesis: true}
-	}
-	for {
-		validatorRequest.PageToken = validatorResponse.NextPageToken
-		validatorResponse, err = pc.client.ListValidators(context.Background(), validatorRequest)
-		if err != nil {
-			logger.Errorf("error retrieving validator response: %v", err)
-			break
-		}
-		if validatorResponse.TotalSize == 0 {
-			break
-		}
 
-		for _, validator := range validatorResponse.ValidatorList {
-
-			balance, exists := validatorBalances[uint64(validator.Index)]
-			if !exists {
-				logger.WithField("pubkey", fmt.Sprintf("%x", validator.Validator.PublicKey)).WithField("epoch", epoch).Errorf("error retrieving validator balance")
-				continue
-			}
-
-			val := &types.Validator{
-				Index:                      uint64(validator.Index),
-				PublicKey:                  validator.Validator.PublicKey,
-				WithdrawalCredentials:      validator.Validator.WithdrawalCredentials,
-				Balance:                    balance,
-				EffectiveBalance:           validator.Validator.EffectiveBalance,
-				Slashed:                    validator.Validator.Slashed,
-				ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-				ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-				ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-				WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-			}
-
-			val.Balance1d = validatorBalances1d[uint64(validator.Index)]
-			val.Balance7d = validatorBalances7d[uint64(validator.Index)]
-			val.Balance31d = validatorBalances31d[uint64(validator.Index)]
-
-			data.Validators = append(data.Validators, val)
-
-		}
-
-		if validatorResponse.NextPageToken == "" {
-			break
-		}
+	for _, validator := range parsedValidators.Data {
+		data.Validators = append(data.Validators, &types.Validator{
+			Index:                      uint64(validator.Index),
+			PublicKey:                  utils.MustParseHex(validator.Validator.Pubkey),
+			WithdrawalCredentials:      utils.MustParseHex(validator.Validator.WithdrawalCredentials),
+			Balance:                    uint64(validator.Balance),
+			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+			Slashed:                    validator.Validator.Slashed,
+			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+			Balance1d:                  validatorBalances1d[uint64(validator.Index)],
+			Balance7d:                  validatorBalances7d[uint64(validator.Index)],
+			Balance31d:                 validatorBalances31d[uint64(validator.Index)],
+			Status:                     validator.Status,
+		})
 	}
 	logger.Printf("retrieved data for %v validators for epoch %v", len(data.Validators), epoch)
 
@@ -1317,6 +1334,10 @@ func (pc *PrysmClient) GetSyncCommittee(stateID string, epoch uint64) (*Standard
 
 // GetSlotData will get the slot data from a Prysm client
 func (pc *PrysmClient) GetSlotData(block *types.Block) (*types.SlotData, error) {
+	if block.Slot > PrysmLatestHeadSlot {
+		PrysmLatestHeadSlot = block.Slot
+	}
+
 	wg := &sync.WaitGroup{}
 	var err error
 

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	GetChainHead() (*types.ChainHead, error)
 	GetEpochData(epoch uint64) (*types.EpochData, error)
+	GetSlotData(block *types.Block) (*types.SlotData, error)
 	GetValidatorQueue() (*types.ValidatorQueue, error)
 	GetEpochAssignments(epoch uint64) (*types.EpochAssignments, error)
 	GetBlocksBySlot(slot uint64) ([]*types.Block, error)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -1,0 +1,329 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"errors"
+	"eth2-exporter/types"
+	"fmt"
+	"strconv"
+)
+
+type bytesHexStr []byte
+
+func (s *bytesHexStr) UnmarshalText(b []byte) error {
+	if s == nil {
+		return fmt.Errorf("cannot unmarshal bytes into nil")
+	}
+	if len(b) >= 2 && b[0] == '0' && b[1] == 'x' {
+		b = b[2:]
+	}
+	out := make([]byte, len(b)/2, len(b)/2)
+	hex.Decode(out, b)
+	*s = out
+	return nil
+}
+
+type uint64Str uint64
+
+func (s *uint64Str) UnmarshalJSON(b []byte) error {
+	return Uint64Unmarshal((*uint64)(s), b)
+}
+
+// Parse a uint64, with or without quotes, in any base, with common prefixes accepted to change base.
+func Uint64Unmarshal(v *uint64, b []byte) error {
+	if v == nil {
+		return errors.New("nil dest in uint64 decoding")
+	}
+	if len(b) == 0 {
+		return errors.New("empty uint64 input")
+	}
+	if b[0] == '"' || b[0] == '\'' {
+		if len(b) == 1 || b[len(b)-1] != b[0] {
+			return errors.New("uneven/missing quotes")
+		}
+		b = b[1 : len(b)-1]
+	}
+	n, err := strconv.ParseUint(string(b), 0, 64)
+	if err != nil {
+		return err
+	}
+	*v = n
+	return nil
+}
+
+type StandardBeaconHeaderResponse struct {
+	Data struct {
+		Root      string `json:"root"`
+		Canonical bool   `json:"canonical"`
+		Header    struct {
+			Message struct {
+				Slot          uint64Str `json:"slot"`
+				ProposerIndex uint64Str `json:"proposer_index"`
+				ParentRoot    string    `json:"parent_root"`
+				StateRoot     string    `json:"state_root"`
+				BodyRoot      string    `json:"body_root"`
+			} `json:"message"`
+			Signature string `json:"signature"`
+		} `json:"header"`
+	} `json:"data"`
+}
+
+type StandardFinalityCheckpointsResponse struct {
+	Data struct {
+		PreviousJustified struct {
+			Epoch uint64Str `json:"epoch"`
+			Root  string    `json:"root"`
+		} `json:"previous_justified"`
+		CurrentJustified struct {
+			Epoch uint64Str `json:"epoch"`
+			Root  string    `json:"root"`
+		} `json:"current_justified"`
+		Finalized struct {
+			Epoch uint64Str `json:"epoch"`
+			Root  string    `json:"root"`
+		} `json:"finalized"`
+	} `json:"data"`
+}
+
+type StandardProposerDuty struct {
+	Pubkey         string    `json:"pubkey"`
+	ValidatorIndex uint64Str `json:"validator_index"`
+	Slot           uint64Str `json:"slot"`
+}
+
+type StandardProposerDutiesResponse struct {
+	DependentRoot string                 `json:"dependent_root"`
+	Data          []StandardProposerDuty `json:"data"`
+}
+
+type StandardCommitteeEntry struct {
+	Index      uint64Str `json:"index"`
+	Slot       uint64Str `json:"slot"`
+	Validators []string  `json:"validators"`
+}
+
+type StandardCommitteesResponse struct {
+	Data []StandardCommitteeEntry `json:"data"`
+}
+
+type StandardSyncCommittee struct {
+	Validators          []string   `json:"validators"`
+	ValidatorAggregates [][]string `json:"validator_aggregates"`
+}
+
+type StandardSyncCommitteesResponse struct {
+	Data StandardSyncCommittee `json:"data"`
+}
+
+type LighthouseValidatorParticipationResponse struct {
+	Data struct {
+		CurrentEpochActiveGwei           uint64Str `json:"current_epoch_active_gwei"`
+		PreviousEpochActiveGwei          uint64Str `json:"previous_epoch_active_gwei"`
+		CurrentEpochTargetAttestingGwei  uint64Str `json:"current_epoch_target_attesting_gwei"`
+		PreviousEpochTargetAttestingGwei uint64Str `json:"previous_epoch_target_attesting_gwei"`
+		PreviousEpochHeadAttestingGwei   uint64Str `json:"previous_epoch_head_attesting_gwei"`
+	} `json:"data"`
+}
+
+type ProposerSlashing struct {
+	SignedHeader1 struct {
+		Message struct {
+			Slot          uint64Str `json:"slot"`
+			ProposerIndex uint64Str `json:"proposer_index"`
+			ParentRoot    string    `json:"parent_root"`
+			StateRoot     string    `json:"state_root"`
+			BodyRoot      string    `json:"body_root"`
+		} `json:"message"`
+		Signature string `json:"signature"`
+	} `json:"signed_header_1"`
+	SignedHeader2 struct {
+		Message struct {
+			Slot          uint64Str `json:"slot"`
+			ProposerIndex uint64Str `json:"proposer_index"`
+			ParentRoot    string    `json:"parent_root"`
+			StateRoot     string    `json:"state_root"`
+			BodyRoot      string    `json:"body_root"`
+		} `json:"message"`
+		Signature string `json:"signature"`
+	} `json:"signed_header_2"`
+}
+
+type AttesterSlashing struct {
+	Attestation1 struct {
+		AttestingIndices []uint64Str `json:"attesting_indices"`
+		Signature        string      `json:"signature"`
+		Data             struct {
+			Slot            uint64Str `json:"slot"`
+			Index           uint64Str `json:"index"`
+			BeaconBlockRoot string    `json:"beacon_block_root"`
+			Source          struct {
+				Epoch uint64Str `json:"epoch"`
+				Root  string    `json:"root"`
+			} `json:"source"`
+			Target struct {
+				Epoch uint64Str `json:"epoch"`
+				Root  string    `json:"root"`
+			} `json:"target"`
+		} `json:"data"`
+	} `json:"attestation_1"`
+	Attestation2 struct {
+		AttestingIndices []uint64Str `json:"attesting_indices"`
+		Signature        string      `json:"signature"`
+		Data             struct {
+			Slot            uint64Str `json:"slot"`
+			Index           uint64Str `json:"index"`
+			BeaconBlockRoot string    `json:"beacon_block_root"`
+			Source          struct {
+				Epoch uint64Str `json:"epoch"`
+				Root  string    `json:"root"`
+			} `json:"source"`
+			Target struct {
+				Epoch uint64Str `json:"epoch"`
+				Root  string    `json:"root"`
+			} `json:"target"`
+		} `json:"data"`
+	} `json:"attestation_2"`
+}
+
+type Attestation struct {
+	AggregationBits string `json:"aggregation_bits"`
+	Signature       string `json:"signature"`
+	Data            struct {
+		Slot            uint64Str `json:"slot"`
+		Index           uint64Str `json:"index"`
+		BeaconBlockRoot string    `json:"beacon_block_root"`
+		Source          struct {
+			Epoch uint64Str `json:"epoch"`
+			Root  string    `json:"root"`
+		} `json:"source"`
+		Target struct {
+			Epoch uint64Str `json:"epoch"`
+			Root  string    `json:"root"`
+		} `json:"target"`
+	} `json:"data"`
+}
+
+type Deposit struct {
+	Proof []string `json:"proof"`
+	Data  struct {
+		Pubkey                string    `json:"pubkey"`
+		WithdrawalCredentials string    `json:"withdrawal_credentials"`
+		Amount                uint64Str `json:"amount"`
+		Signature             string    `json:"signature"`
+	} `json:"data"`
+}
+
+type VoluntaryExit struct {
+	Message struct {
+		Epoch          uint64Str `json:"epoch"`
+		ValidatorIndex uint64Str `json:"validator_index"`
+	} `json:"message"`
+	Signature string `json:"signature"`
+}
+
+type Eth1Data struct {
+	DepositRoot  string    `json:"deposit_root"`
+	DepositCount uint64Str `json:"deposit_count"`
+	BlockHash    string    `json:"block_hash"`
+}
+
+type SyncAggregate struct {
+	SyncCommitteeBits      string `json:"sync_committee_bits"`
+	SyncCommitteeSignature string `json:"sync_committee_signature"`
+}
+
+// https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
+// https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#executionpayload
+type ExecutionPayload struct {
+	ParentHash    bytesHexStr   `json:"parent_hash"`
+	FeeRecipient  bytesHexStr   `json:"fee_recipient"`
+	StateRoot     bytesHexStr   `json:"state_root"`
+	ReceiptsRoot  bytesHexStr   `json:"receipts_root"`
+	LogsBloom     bytesHexStr   `json:"logs_bloom"`
+	PrevRandao    bytesHexStr   `json:"prev_randao"`
+	BlockNumber   uint64Str     `json:"block_number"`
+	GasLimit      uint64Str     `json:"gas_limit"`
+	GasUsed       uint64Str     `json:"gas_used"`
+	Timestamp     uint64Str     `json:"timestamp"`
+	ExtraData     bytesHexStr   `json:"extra_data"`
+	BaseFeePerGas uint64Str     `json:"base_fee_per_gas"`
+	BlockHash     bytesHexStr   `json:"block_hash"`
+	Transactions  []bytesHexStr `json:"transactions"`
+}
+
+type AnySignedBlock struct {
+	Message struct {
+		Slot          uint64Str `json:"slot"`
+		ProposerIndex uint64Str `json:"proposer_index"`
+		ParentRoot    string    `json:"parent_root"`
+		StateRoot     string    `json:"state_root"`
+		Body          struct {
+			RandaoReveal      string             `json:"randao_reveal"`
+			Eth1Data          Eth1Data           `json:"eth1_data"`
+			Graffiti          string             `json:"graffiti"`
+			ProposerSlashings []ProposerSlashing `json:"proposer_slashings"`
+			AttesterSlashings []AttesterSlashing `json:"attester_slashings"`
+			Attestations      []Attestation      `json:"attestations"`
+			Deposits          []Deposit          `json:"deposits"`
+			VoluntaryExits    []VoluntaryExit    `json:"voluntary_exits"`
+
+			// not present in phase0 blocks
+			SyncAggregate *SyncAggregate `json:"sync_aggregate,omitempty"`
+
+			// not present in phase0/altair blocks
+			ExecutionPayload *ExecutionPayload `json:"execution_payload"`
+		} `json:"body"`
+	} `json:"message"`
+	Signature bytesHexStr `json:"signature"`
+}
+
+type StandardV2BlockResponse struct {
+	Version string         `json:"version"`
+	Data    AnySignedBlock `json:"data"`
+}
+
+type StandardV1BlockRootResponse struct {
+	Data struct {
+		Root string `json:"root"`
+	} `json:"data"`
+}
+
+type StandardValidatorEntry struct {
+	Index     uint64Str `json:"index"`
+	Balance   uint64Str `json:"balance"`
+	Status    string    `json:"status"`
+	Validator struct {
+		Pubkey                     string    `json:"pubkey"`
+		WithdrawalCredentials      string    `json:"withdrawal_credentials"`
+		EffectiveBalance           uint64Str `json:"effective_balance"`
+		Slashed                    bool      `json:"slashed"`
+		ActivationEligibilityEpoch uint64Str `json:"activation_eligibility_epoch"`
+		ActivationEpoch            uint64Str `json:"activation_epoch"`
+		ExitEpoch                  uint64Str `json:"exit_epoch"`
+		WithdrawableEpoch          uint64Str `json:"withdrawable_epoch"`
+	} `json:"validator"`
+}
+
+type StandardValidatorsResponse struct {
+	Data []StandardValidatorEntry `json:"data"`
+}
+
+func (pc *LighthouseClient) GetBlockStatusByEpoch(epoch uint64) ([]*types.CanonBlock, error) {
+	blocks := make([]*types.CanonBlock, 0)
+	return blocks, nil
+}
+
+type StandardSyncingResponse struct {
+	Data struct {
+		IsSyncing    bool      `json:"is_syncing"`
+		HeadSlot     uint64Str `json:"head_slot"`
+		SyncDistance uint64Str `json:"sync_distance"`
+	} `json:"data"`
+}
+
+type StandardValidatorBalancesResponse struct {
+	Data []struct {
+		Index   uint64Str `json:"index"`
+		Balance uint64Str `json:"balance"`
+	} `json:"data"`
+}

--- a/types/exporter.go
+++ b/types/exporter.go
@@ -44,6 +44,14 @@ type EpochData struct {
 	EpochParticipationStats *ValidatorParticipation
 }
 
+// SlotData is a struct to hold slot data
+type SlotData struct {
+	Epoch      uint64
+	Slot       uint64
+	Validators []*Validator
+	Blocks     map[uint64]map[string]*Block
+}
+
 // ValidatorParticipation is a struct to hold validator participation data
 type ValidatorParticipation struct {
 	Epoch                   uint64


### PR DESCRIPTION
인출이 발생한 다음 슬롯에서 모든 리워드가 정상적으로 처리됨을 확인함
인출발생 시잠의 슬롯에서는 -로 표기됨, 이것을 해결하기 위해서는 현재는 에포크 단위로만 데이타베이스에 저장한다. 이것을 슬롯단위로 저장소를 늘려야 한다.
너무 큰 변경이 예상된다.
